### PR TITLE
feat: add temporary upload URLs with token-based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1-dev.2] - 2025-10-11
+
+### Added
+
+#### Server
+
+- **Temporary Upload URLs**: Generate secure, single-use upload tokens for client-side uploads
+  - `POST /upload_tokens` - Create temporary upload token (requires API key)
+  - `POST /upload_tokens/{token}` - Upload image with token (no API key required)
+  - 15-minute token expiration
+  - Single-use enforcement (tokens automatically deleted after first upload)
+  - Cryptographically secure token generation (32 random bytes, base64url encoded)
+  - In-memory token storage with automatic cleanup
+- Shared image upload utilities (`lib/src/image_upload_utils.dart`) for consistent validation and processing
+  - Centralized `processImageUpload()` function
+  - `ImageUploadResult` class for structured response data
+  - `ImageUploadException` for better error handling
+
+#### Client Library
+
+- `createTemporaryUploadUrl()` - Generate temporary upload token (authenticated)
+- `uploadImageWithToken()` - Upload image using temporary token (no API key needed)
+- `TemporaryUploadUrl` model with full serialization support
+- Updated examples demonstrating temporary upload workflow
+
+### Changed
+
+#### Server
+
+- Refactored upload endpoints to use shared utilities
+- Reduced code duplication by ~200 lines across upload endpoints
+- Improved consistency in upload validation and error handling
+
+#### Documentation
+
+- Updated README with temporary upload URL documentation
+- Added security features section for temporary URLs
+- Updated client library README with usage examples
+- Enhanced API endpoint documentation
+
+### Security
+
+- Temporary upload tokens provide secure alternative to exposing API keys in client applications
+- Same security validations apply to token-based uploads (magic byte checking, file size limits)
+
+## [0.0.1-dev.1] - 2025-10-09
+
+### Added
+
+#### Server
+
+- **Image Upload & Storage**
+  - `POST /files` - Upload images via multipart form data
+  - `PUT /files/{fileName}` - Upload with custom filename
+  - Secure filename generation with timestamp and random suffix
+  - Metadata storage preserving original filenames
+- **Image Retrieval**
+  - `GET /files/{fileName}` - Retrieve original images
+  - `GET /files/{transformations}/{fileName}` - On-the-fly image transformations
+- **Image Management**
+  - `DELETE /files/{fileName}` - Delete images (authenticated)
+  - `GET /files` - List all images with metadata (authenticated)
+- **Web Dashboard**
+  - Modern, responsive UI at `/dashboard`
+  - Drag-and-drop image upload
+  - Image preview and management
+  - Copy public URLs
+  - Search/filter by filename
+- **Security Features**
+  - Magic byte validation for file type verification
+  - 10MB file size limit
+  - API key authentication (x-api-key header)
+  - Secure filename generation prevents path traversal
+  - Allowed file types: JPEG, PNG, GIF, WebP
+- **Performance & Delivery**
+  - Configurable cache headers (default: 7 days)
+  - CDN-compatible cache control
+  - CORS support for cross-origin requests
+- **Image Transformation**
+  - On-the-fly resizing by width and/or height
+  - Quality adjustment (1-100)
+  - URL-based transformation parameters
+- **Infrastructure**
+  - Production-ready Dockerfile
+  - Multi-architecture support (amd64, arm64)
+  - Environment-based configuration
+  - Request logging middleware
+
+#### Client Library (`image_service_client`)
+
+- **Core Functionality**
+  - `uploadImage()` - Multipart form upload
+  - `uploadImageWithFilename()` - Upload with custom filename (PUT)
+  - `getImage()` - Download image bytes (with optional transformations)
+  - `getImageUrl()` - Generate image URLs (with optional transformations)
+  - `deleteImage()` - Delete images
+  - `listImages()` - List all images with metadata
+- **Models**
+  - `ImageMetadata` - Image information with serialization
+  - `ImageTransformOptions` - Transformation parameters
+  - `UploadResponse` - Upload result data
+  - `ImageServiceException` - Typed error handling
+- **Features**
+  - Built-in API key authentication
+  - Type-safe API with full documentation
+  - dart_mappable for efficient serialization
+  - Testable architecture with dependency injection support
+
+#### Documentation
+
+- Comprehensive README with setup instructions
+- API endpoint documentation with curl examples
+- Docker deployment guide
+- Client library usage examples
+- Security features documentation
+- Project structure overview
+
+#### Development Tools
+
+- `very_good_analysis` linting rules
+- Unit test suite
+- Code coverage reporting
+- CI/CD with Shorebird
+
+### Technical Details
+
+- Built with Dart Frog web framework
+- Dart SDK 3.7.0+
+- Image processing with `package:image`
+- MIME type detection with `package:mime`
+- HTML generation with `dart_frog_html`
+
+[0.0.1-dev.2]: https://github.com/mtwichel/image_service/compare/v0.0.1-dev.1...v0.0.1-dev.2
+[0.0.1-dev.1]: https://github.com/mtwichel/image_service/releases/tag/v0.0.1-dev.1

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A high-performance image storage and serving service built with Dart and Dart Fr
 
 - 🖼️ **Image Upload & Storage** - Upload images via web dashboard or REST API
 - 🔒 **Security First** - File validation using magic byte checking, size limits, and API key authentication
+- ⏰ **Temporary Upload URLs** - Generate secure, single-use upload tokens for client-side uploads
 - 🎨 **Image Transformation** - On-the-fly image resizing and quality adjustment
 - 📊 **Web Dashboard** - Modern, responsive UI for managing images
 - 🚀 **High Performance** - Built-in caching headers and optimized delivery
@@ -207,6 +208,46 @@ All authenticated endpoints require the `x-api-key` header:
 ```bash
 x-api-key: your-secret-api-key
 ```
+
+#### Create Temporary Upload URL (POST)
+
+Generate a temporary, single-use upload token that expires in 15 minutes:
+
+```bash
+curl -X POST \
+  -H "x-api-key: your-secret-api-key" \
+  http://localhost:8080/upload_tokens
+```
+
+Response:
+
+```json
+{
+  "token": "abc123...",
+  "uploadUrl": "/upload_tokens/abc123...",
+  "expiresAt": "2024-01-01T12:15:00.000Z",
+  "expiresIn": 900
+}
+```
+
+**Security Features:**
+
+- Requires API key authentication to create
+- Token is single-use (deleted after first upload)
+- Expires after 15 minutes
+- Cryptographically secure (32 random bytes)
+
+#### Upload with Token (POST)
+
+Upload an image using a temporary token (no API key required):
+
+```bash
+curl -X POST \
+  -F "file=@image.jpg" \
+  http://localhost:8080/upload_tokens/{token}
+```
+
+**Note:** This endpoint does NOT require the `x-api-key` header. The token itself provides authentication.
 
 #### Upload Image (POST)
 

--- a/image_service_client/CHANGELOG.md
+++ b/image_service_client/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the Image Service Client will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-dev.2] - 2025-10-11
+
+### Added
+
+- **Temporary Upload URLs**: Secure, token-based upload functionality
+  - `createTemporaryUploadUrl()` - Generate temporary upload token (requires API key)
+  - `uploadImageWithToken()` - Upload image using temporary token (no API key required)
+  - `TemporaryUploadUrl` model with full serialization support
+- Support for uploading images without exposing API keys to client applications
+- Updated examples demonstrating temporary upload workflow
+
+### Changed
+
+- Refactored imports to use consolidated models export
+- Enhanced documentation with temporary upload URL usage examples
+- Improved example application with additional upload scenarios
+
+### Security
+
+- Temporary tokens provide secure alternative to exposing API keys in client applications
+- Tokens are single-use and expire after 15 minutes
+- Same security validations apply (magic byte checking, file size limits)
+
 ## [0.0.1-dev.1] - 2025-10-10
 
 ### Added
@@ -29,3 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - API key authentication via x-api-key header
 - Support for custom HTTP client for testing and proxy configurations
+
+[0.0.1-dev.2]: https://github.com/mtwichel/image_service/compare/v0.0.1-dev.1...v0.0.1-dev.2
+[0.0.1-dev.1]: https://github.com/mtwichel/image_service/releases/tag/v0.0.1-dev.1

--- a/image_service_client/README.md
+++ b/image_service_client/README.md
@@ -8,6 +8,7 @@ A Dart client library for interacting with the Image Service server. Provides a 
 ## Features
 
 - 📤 **Upload Images** - Multipart form upload or binary PUT with custom filename
+- ⏰ **Temporary Upload URLs** - Generate secure, single-use tokens for client-side uploads
 - 📥 **Retrieve Images** - Get original or transformed versions
 - 🎨 **Transform Images** - On-the-fly resizing and quality adjustment
 - 🗑️ **Delete Images** - Remove images from the server
@@ -65,6 +66,35 @@ final response = await client.uploadImageWithFilename(
 
 print('Uploaded: ${response.url}');
 ```
+
+**Using temporary upload token (no API key needed):**
+
+Temporary upload URLs allow you to generate a secure, single-use token that clients can use to upload images directly without exposing your API key. Perfect for client-side uploads in mobile or web apps.
+
+```dart
+// Step 1: Create a temporary upload URL (requires API key)
+final tempUrl = await client.createTemporaryUploadUrl();
+
+print('Token: ${tempUrl.token}');
+print('Expires in: ${tempUrl.expiresIn} seconds');
+
+// Step 2: Use the token to upload (no API key needed!)
+// This can be done from a mobile app or browser without exposing your API key
+final response = await client.uploadImageWithToken(
+  token: tempUrl.token,
+  imageBytes: imageBytes,
+  fileName: 'photo.jpg', // optional
+);
+
+print('Uploaded: ${response.url}');
+```
+
+**Security Features:**
+
+- Token is single-use (automatically deleted after upload)
+- Expires after 15 minutes
+- Cryptographically secure (32 random bytes)
+- Perfect for client-side uploads without exposing API keys
 
 ### Retrieve an Image
 

--- a/image_service_client/example/example.dart
+++ b/image_service_client/example/example.dart
@@ -74,13 +74,33 @@ Future<void> main() async {
       print('     Size: ${image.size} bytes');
     }
 
-    // Example 7: Delete an image
-    print('7. Deleting image...');
-    await client.deleteImage(uploadResponse.fileName);
-    print('   Deleted: ${uploadResponse.fileName}\n');
+    // Example 7: Create temporary upload URL
+    print('7. Creating temporary upload URL...');
+    final tempUrl = await client.createTemporaryUploadUrl();
+    print('   Token: ${tempUrl.token}');
+    print('   Upload URL: ${tempUrl.uploadUrl}');
+    print('   Expires at: ${tempUrl.expiresAt}');
+    print('   Expires in: ${tempUrl.expiresIn} seconds\n');
 
-    // Example 8: Error handling
-    print('8. Error handling example...');
+    // Example 8: Upload with temporary token (no API key needed)
+    print('8. Uploading with temporary token...');
+    final tokenUpload = await client.uploadImageWithToken(
+      token: tempUrl.token,
+      imageBytes: imageBytes,
+      fileName: 'token-upload-example.jpg',
+    );
+    print('   Uploaded: ${tokenUpload.url}');
+    print('   File name: ${tokenUpload.fileName}\n');
+
+    // Example 9: Delete images
+    print('9. Deleting images...');
+    await client.deleteImage(uploadResponse.fileName);
+    print('   Deleted: ${uploadResponse.fileName}');
+    await client.deleteImage(tokenUpload.fileName);
+    print('   Deleted: ${tokenUpload.fileName}\n');
+
+    // Example 10: Error handling
+    print('10. Error handling example...');
     try {
       await client.getImage('non-existent-file.jpg');
     } on ImageServiceException catch (e) {

--- a/image_service_client/lib/image_service_client.dart
+++ b/image_service_client/lib/image_service_client.dart
@@ -4,4 +4,5 @@ library;
 export 'src/image_service_client.dart';
 export 'src/models/image_metadata.dart';
 export 'src/models/image_transform_options.dart';
+export 'src/models/temporary_upload_url.dart';
 export 'src/models/upload_response.dart';

--- a/image_service_client/lib/src/models/models.dart
+++ b/image_service_client/lib/src/models/models.dart
@@ -1,0 +1,4 @@
+export 'image_metadata.dart';
+export 'image_transform_options.dart';
+export 'temporary_upload_url.dart';
+export 'upload_response.dart';

--- a/image_service_client/lib/src/models/temporary_upload_url.dart
+++ b/image_service_client/lib/src/models/temporary_upload_url.dart
@@ -1,0 +1,43 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'temporary_upload_url.mapper.dart';
+
+/// {@template temporary_upload_url}
+/// Response from creating a temporary upload URL
+///
+/// Contains:
+/// - [token] - The temporary upload token
+/// - [uploadUrl] - The relative URL path to upload to
+/// - [expiresAt] - When the token expires
+/// - [expiresIn] - Seconds until expiration
+/// {@endtemplate}
+@MappableClass()
+class TemporaryUploadUrl with TemporaryUploadUrlMappable {
+  /// {@macro temporary_upload_url}
+  const TemporaryUploadUrl({
+    required this.token,
+    required this.uploadUrl,
+    required this.expiresAt,
+    required this.expiresIn,
+  });
+
+  /// The temporary upload token (single-use, expires in 15 minutes)
+  final String token;
+
+  /// The relative URL path to upload to (e.g., '/upload_tokens/abc123')
+  final String uploadUrl;
+
+  /// ISO8601 timestamp when the token expires
+  final DateTime expiresAt;
+
+  /// Number of seconds until the token expires
+  final int expiresIn;
+
+  /// Creates a [TemporaryUploadUrl] from a JSON map
+  static const TemporaryUploadUrl Function(Map<String, dynamic>) fromMap =
+      TemporaryUploadUrlMapper.fromMap;
+
+  /// Creates a [TemporaryUploadUrl] from a JSON string
+  static const TemporaryUploadUrl Function(String) fromJson =
+      TemporaryUploadUrlMapper.fromJson;
+}

--- a/image_service_client/lib/src/models/temporary_upload_url.mapper.dart
+++ b/image_service_client/lib/src/models/temporary_upload_url.mapper.dart
@@ -1,0 +1,179 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'temporary_upload_url.dart';
+
+class TemporaryUploadUrlMapper extends ClassMapperBase<TemporaryUploadUrl> {
+  TemporaryUploadUrlMapper._();
+
+  static TemporaryUploadUrlMapper? _instance;
+  static TemporaryUploadUrlMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TemporaryUploadUrlMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TemporaryUploadUrl';
+
+  static String _$token(TemporaryUploadUrl v) => v.token;
+  static const Field<TemporaryUploadUrl, String> _f$token = Field(
+    'token',
+    _$token,
+  );
+  static String _$uploadUrl(TemporaryUploadUrl v) => v.uploadUrl;
+  static const Field<TemporaryUploadUrl, String> _f$uploadUrl = Field(
+    'uploadUrl',
+    _$uploadUrl,
+  );
+  static DateTime _$expiresAt(TemporaryUploadUrl v) => v.expiresAt;
+  static const Field<TemporaryUploadUrl, DateTime> _f$expiresAt = Field(
+    'expiresAt',
+    _$expiresAt,
+  );
+  static int _$expiresIn(TemporaryUploadUrl v) => v.expiresIn;
+  static const Field<TemporaryUploadUrl, int> _f$expiresIn = Field(
+    'expiresIn',
+    _$expiresIn,
+  );
+
+  @override
+  final MappableFields<TemporaryUploadUrl> fields = const {
+    #token: _f$token,
+    #uploadUrl: _f$uploadUrl,
+    #expiresAt: _f$expiresAt,
+    #expiresIn: _f$expiresIn,
+  };
+
+  static TemporaryUploadUrl _instantiate(DecodingData data) {
+    return TemporaryUploadUrl(
+      token: data.dec(_f$token),
+      uploadUrl: data.dec(_f$uploadUrl),
+      expiresAt: data.dec(_f$expiresAt),
+      expiresIn: data.dec(_f$expiresIn),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TemporaryUploadUrl fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TemporaryUploadUrl>(map);
+  }
+
+  static TemporaryUploadUrl fromJson(String json) {
+    return ensureInitialized().decodeJson<TemporaryUploadUrl>(json);
+  }
+}
+
+mixin TemporaryUploadUrlMappable {
+  String toJson() {
+    return TemporaryUploadUrlMapper.ensureInitialized()
+        .encodeJson<TemporaryUploadUrl>(this as TemporaryUploadUrl);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TemporaryUploadUrlMapper.ensureInitialized()
+        .encodeMap<TemporaryUploadUrl>(this as TemporaryUploadUrl);
+  }
+
+  TemporaryUploadUrlCopyWith<
+    TemporaryUploadUrl,
+    TemporaryUploadUrl,
+    TemporaryUploadUrl
+  >
+  get copyWith =>
+      _TemporaryUploadUrlCopyWithImpl<TemporaryUploadUrl, TemporaryUploadUrl>(
+        this as TemporaryUploadUrl,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return TemporaryUploadUrlMapper.ensureInitialized().stringifyValue(
+      this as TemporaryUploadUrl,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TemporaryUploadUrlMapper.ensureInitialized().equalsValue(
+      this as TemporaryUploadUrl,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return TemporaryUploadUrlMapper.ensureInitialized().hashValue(
+      this as TemporaryUploadUrl,
+    );
+  }
+}
+
+extension TemporaryUploadUrlValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TemporaryUploadUrl, $Out> {
+  TemporaryUploadUrlCopyWith<$R, TemporaryUploadUrl, $Out>
+  get $asTemporaryUploadUrl => $base.as(
+    (v, t, t2) => _TemporaryUploadUrlCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class TemporaryUploadUrlCopyWith<
+  $R,
+  $In extends TemporaryUploadUrl,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({
+    String? token,
+    String? uploadUrl,
+    DateTime? expiresAt,
+    int? expiresIn,
+  });
+  TemporaryUploadUrlCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _TemporaryUploadUrlCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TemporaryUploadUrl, $Out>
+    implements TemporaryUploadUrlCopyWith<$R, TemporaryUploadUrl, $Out> {
+  _TemporaryUploadUrlCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TemporaryUploadUrl> $mapper =
+      TemporaryUploadUrlMapper.ensureInitialized();
+  @override
+  $R call({
+    String? token,
+    String? uploadUrl,
+    DateTime? expiresAt,
+    int? expiresIn,
+  }) => $apply(
+    FieldCopyWithData({
+      if (token != null) #token: token,
+      if (uploadUrl != null) #uploadUrl: uploadUrl,
+      if (expiresAt != null) #expiresAt: expiresAt,
+      if (expiresIn != null) #expiresIn: expiresIn,
+    }),
+  );
+  @override
+  TemporaryUploadUrl $make(CopyWithData data) => TemporaryUploadUrl(
+    token: data.get(#token, or: $value.token),
+    uploadUrl: data.get(#uploadUrl, or: $value.uploadUrl),
+    expiresAt: data.get(#expiresAt, or: $value.expiresAt),
+    expiresIn: data.get(#expiresIn, or: $value.expiresIn),
+  );
+
+  @override
+  TemporaryUploadUrlCopyWith<$R2, TemporaryUploadUrl, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _TemporaryUploadUrlCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/image_service_client/pubspec.yaml
+++ b/image_service_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_service_client
 description: A client library of the "image service" server
-version: 0.0.1-dev.1
+version: 0.0.1-dev.2
 repository: https://github.com/mtwichel/image_service/
 
 environment:

--- a/lib/src/image_upload_utils.dart
+++ b/lib/src/image_upload_utils.dart
@@ -1,0 +1,224 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+/// Maximum allowed file size (10MB)
+const maxImageFileSize = 10 * 1024 * 1024;
+
+/// Image data directory path
+const imageDirectory = 'data/images';
+
+/// Validates if the provided bytes represent a valid image file
+///
+/// Uses magic byte checking to verify actual file type:
+/// - JPEG: FF D8 FF
+/// - PNG: 89 50 4E 47
+/// - GIF: 47 49 46 38
+/// - WebP: RIFF...WEBP
+bool isValidImageFile(List<int> bytes) {
+  if (bytes.length < 8) return false;
+
+  // Check magic bytes for common image formats
+  final header = bytes.take(8).toList();
+
+  // JPEG: FF D8 FF
+  if (header[0] == 0xFF && header[1] == 0xD8 && header[2] == 0xFF) return true;
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (header[0] == 0x89 &&
+      header[1] == 0x50 &&
+      header[2] == 0x4E &&
+      header[3] == 0x47) {
+    return true;
+  }
+
+  // GIF: 47 49 46 38
+  if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46) return true;
+
+  // WebP: 52 49 46 46 (RIFF) at bytes 0-3 and 57 45 42 50 (WEBP) at bytes 8-11
+  if (bytes.length >= 12 &&
+      bytes[0] == 0x52 && // 'R'
+      bytes[1] == 0x49 && // 'I'
+      bytes[2] == 0x46 && // 'F'
+      bytes[3] == 0x46 && // 'F'
+      bytes[8] == 0x57 && // 'W'
+      bytes[9] == 0x45 && // 'E'
+      bytes[10] == 0x42 && // 'B'
+      bytes[11] == 0x50) {
+    // 'P'
+    return true;
+  }
+
+  return false;
+}
+
+/// Generates a cryptographically secure filename
+///
+/// Format: {timestamp}_{random}
+/// Example: 1234567890_123456
+String generateSecureFileName() {
+  final timestamp = DateTime.now().millisecondsSinceEpoch;
+  final random = Random().nextInt(999999);
+  return '${timestamp}_$random';
+}
+
+/// Extracts and validates file extension from filename
+///
+/// Returns a safe extension from the allowed list:
+/// .jpg, .jpeg, .png, .gif, .webp
+///
+/// Defaults to .jpg if extension is invalid or missing
+String getFileExtension(String filename) {
+  if (filename.isEmpty) return '.jpg';
+  final lastDot = filename.lastIndexOf('.');
+  if (lastDot == -1) return '.jpg';
+
+  final extension = filename.substring(lastDot).toLowerCase();
+  // Only allow safe image extensions
+  const allowedExtensions = {'.jpg', '.jpeg', '.png', '.gif', '.webp'};
+  return allowedExtensions.contains(extension) ? extension : '.jpg';
+}
+
+/// Saves metadata for an uploaded image
+///
+/// Creates a .meta file alongside the image containing:
+/// - originalName: The user-provided filename
+/// - uploadedAt: ISO8601 timestamp
+/// - secureFileName: The generated secure filename
+Future<void> saveMetadata(
+  String directoryPath,
+  String secureFileName,
+  String originalName,
+) async {
+  final metadataFile = File('$directoryPath/$secureFileName.meta');
+  final metadata = {
+    'originalName': originalName,
+    'uploadedAt': DateTime.now().toIso8601String(),
+    'secureFileName': secureFileName,
+  };
+  await metadataFile.writeAsString(jsonEncode(metadata));
+}
+
+/// Loads metadata for an image file
+///
+/// Returns null if metadata file doesn't exist or cannot be read
+Map<String, dynamic>? loadMetadata(
+  String directoryPath,
+  String secureFileName,
+) {
+  try {
+    final metadataFile = File('$directoryPath/$secureFileName.meta');
+    if (!metadataFile.existsSync()) return null;
+    final content = metadataFile.readAsStringSync();
+    return jsonDecode(content) as Map<String, dynamic>;
+  } catch (e) {
+    return null;
+  }
+}
+
+/// Gets the display name for a file (original name from metadata)
+///
+/// Falls back to secure filename if metadata is unavailable
+String getDisplayName(String directoryPath, String secureFileName) {
+  final metadata = loadMetadata(directoryPath, secureFileName);
+  return metadata?['originalName'] as String? ?? secureFileName;
+}
+
+/// Result of a successful image upload operation
+class ImageUploadResult {
+  /// Creates an [ImageUploadResult]
+  const ImageUploadResult({
+    required this.secureFileName,
+    required this.originalName,
+    required this.fileSize,
+  });
+
+  /// The generated secure filename
+  final String secureFileName;
+
+  /// The original filename provided by the user
+  final String originalName;
+
+  /// Size of the uploaded file in bytes
+  final int fileSize;
+
+  /// Converts to a JSON response map
+  Map<String, dynamic> toJson() => {
+    'url': '/files/$secureFileName',
+    'fileName': secureFileName,
+    'originalName': originalName,
+    'size': fileSize,
+  };
+}
+
+/// Validates and processes an image upload
+///
+/// Performs:
+/// - File size validation (max 10MB)
+/// - Magic byte validation for file type
+/// - Secure filename generation
+/// - File storage
+/// - Metadata storage
+///
+/// Returns [ImageUploadResult] on success
+/// Throws [ImageUploadException] on validation or storage failure
+Future<ImageUploadResult> processImageUpload({
+  required List<int> bytes,
+  required String originalFileName,
+}) async {
+  // Security: Validate file size (max 10MB)
+  if (bytes.length > maxImageFileSize) {
+    throw const ImageUploadException(
+      statusCode: HttpStatus.requestEntityTooLarge,
+      message: 'File too large. Maximum size is 10MB.',
+    );
+  }
+
+  // Security: Validate file type by checking magic bytes
+  if (!isValidImageFile(bytes)) {
+    throw const ImageUploadException(
+      statusCode: HttpStatus.badRequest,
+      message:
+          'Invalid file type. Only images (JPEG, PNG, GIF, WebP) are allowed.',
+    );
+  }
+
+  // Security: Generate secure filename to prevent conflicts and traversal
+  final originalName = originalFileName.isNotEmpty ? originalFileName : 'image';
+  final extension = getFileExtension(originalName);
+  final secureFileName = '${generateSecureFileName()}$extension';
+
+  // Ensure the directory exists
+  final directory = Directory(imageDirectory);
+  if (!directory.existsSync()) {
+    directory.createSync(recursive: true);
+  }
+
+  // Save the file with secure filename
+  final file = File('${directory.path}/$secureFileName');
+  await file.writeAsBytes(bytes);
+
+  // Save metadata with original filename
+  await saveMetadata(directory.path, secureFileName, originalName);
+
+  return ImageUploadResult(
+    secureFileName: secureFileName,
+    originalName: originalName,
+    fileSize: bytes.length,
+  );
+}
+
+/// Exception thrown during image upload processing
+class ImageUploadException implements Exception {
+  /// Creates an [ImageUploadException]
+  const ImageUploadException({required this.statusCode, required this.message});
+
+  /// HTTP status code for the error
+  final int statusCode;
+
+  /// Error message
+  final String message;
+
+  @override
+  String toString() => 'ImageUploadException: $statusCode - $message';
+}

--- a/lib/src/temporary_upload_token_store.dart
+++ b/lib/src/temporary_upload_token_store.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'dart:math';
+
+/// A token entry with expiration information
+class _TokenEntry {
+  _TokenEntry({required this.createdAt, required this.expiresAt});
+
+  final DateTime createdAt;
+  final DateTime expiresAt;
+
+  bool get isExpired => DateTime.now().isAfter(expiresAt);
+}
+
+/// In-memory store for temporary upload tokens
+///
+/// Tokens are:
+/// - Cryptographically secure (32 random bytes, base64url encoded)
+/// - Single-use (deleted after first successful validation)
+/// - Time-limited (15 minute expiration by default)
+class TemporaryUploadTokenStore {
+  /// Creates a [TemporaryUploadTokenStore]
+  ///
+  /// [tokenDuration] - How long tokens remain valid (default: 15 minutes)
+  /// [random] - Random number generator (defaults to Random.secure())
+  TemporaryUploadTokenStore({
+    this.tokenDuration = const Duration(minutes: 15),
+    Random? random,
+  }) : _random = random ?? Random.secure();
+
+  /// Duration for which tokens are valid
+  final Duration tokenDuration;
+
+  /// Secure random number generator for token creation
+  final Random _random;
+
+  /// In-memory token storage
+  final Map<String, _TokenEntry> _tokens = {};
+
+  /// Generates a new cryptographically secure token
+  ///
+  /// Returns a tuple of (token, expiresAt)
+  (String, DateTime) generateToken() {
+    // Generate 32 random bytes for security
+    final bytes = List<int>.generate(32, (_) => _random.nextInt(256));
+    final token = base64Url.encode(bytes).replaceAll('=', '');
+
+    final now = DateTime.now();
+    final expiresAt = now.add(tokenDuration);
+
+    _tokens[token] = _TokenEntry(createdAt: now, expiresAt: expiresAt);
+
+    return (token, expiresAt);
+  }
+
+  /// Validates and consumes a token (single-use)
+  ///
+  /// Returns true if the token is valid and not expired.
+  /// The token is removed from the store after this call.
+  bool validateAndConsumeToken(String token) {
+    final entry = _tokens.remove(token);
+
+    if (entry == null) {
+      return false;
+    }
+
+    // Clean up expired tokens opportunistically
+    _cleanupExpiredTokens();
+
+    return !entry.isExpired;
+  }
+
+  /// Removes all expired tokens from the store
+  void _cleanupExpiredTokens() {
+    _tokens.removeWhere((_, entry) => entry.isExpired);
+  }
+
+  /// Gets the current number of active tokens (for testing/monitoring)
+  int get activeTokenCount => _tokens.length;
+
+  /// Clears all tokens (for testing)
+  void clear() {
+    _tokens.clear();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_service
 description: A service for storing and retrieving images
-version: 0.0.1-dev.1
+version: 0.0.1-dev.2
 publish_to: none
 
 environment:

--- a/routes/_middleware.dart
+++ b/routes/_middleware.dart
@@ -1,12 +1,17 @@
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
+import 'package:image_service/src/temporary_upload_token_store.dart';
+
+// Singleton token store instance
+final _tokenStore = TemporaryUploadTokenStore();
 
 Handler middleware(Handler handler) {
   return handler
       .use(requestLogger())
       .use(_corsMiddleware)
-      .use(_cacheControlMiddleware);
+      .use(_cacheControlMiddleware)
+      .use(provider<TemporaryUploadTokenStore>((_) => _tokenStore));
 }
 
 const _corsHeaders = {

--- a/routes/files/index.dart
+++ b/routes/files/index.dart
@@ -1,99 +1,10 @@
 // ignore_for_file: lines_longer_than_80_chars
 
-import 'dart:convert';
 import 'dart:io';
-import 'dart:math';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:dart_frog_html/dart_frog_html.dart';
-
-// Security validation functions
-bool _isValidImageFile(List<int> bytes) {
-  if (bytes.length < 8) return false;
-
-  // Check magic bytes for common image formats
-  final header = bytes.take(8).toList();
-
-  // JPEG: FF D8 FF
-  if (header[0] == 0xFF && header[1] == 0xD8 && header[2] == 0xFF) return true;
-
-  // PNG: 89 50 4E 47 0D 0A 1A 0A
-  if (header[0] == 0x89 &&
-      header[1] == 0x50 &&
-      header[2] == 0x4E &&
-      header[3] == 0x47) {
-    return true;
-  }
-
-  // GIF: 47 49 46 38
-  if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46) return true;
-
-  // WebP: 52 49 46 46 (RIFF) at bytes 0-3 and 57 45 42 50 (WEBB) at bytes 8-11
-  if (bytes.length >= 12 &&
-      bytes[0] == 0x52 && // 'R'
-      bytes[1] == 0x49 && // 'I'
-      bytes[2] == 0x46 && // 'F'
-      bytes[3] == 0x46 && // 'F'
-      bytes[8] == 0x57 && // 'W'
-      bytes[9] == 0x45 && // 'E'
-      bytes[10] == 0x42 && // 'B'
-      bytes[11] == 0x50) {
-    // 'P'
-    return true;
-  }
-
-  return false;
-}
-
-String _generateSecureFileName() {
-  final timestamp = DateTime.now().millisecondsSinceEpoch;
-  final random = Random().nextInt(999999);
-  return '${timestamp}_$random';
-}
-
-String _getFileExtension(String filename) {
-  if (filename.isEmpty) return '.jpg';
-  final lastDot = filename.lastIndexOf('.');
-  if (lastDot == -1) return '.jpg';
-
-  final extension = filename.substring(lastDot).toLowerCase();
-  // Only allow safe image extensions
-  const allowedExtensions = {'.jpg', '.jpeg', '.png', '.gif', '.webp'};
-  return allowedExtensions.contains(extension) ? extension : '.jpg';
-}
-
-Future<void> _saveMetadata(
-  String directoryPath,
-  String secureFileName,
-  String originalName,
-) async {
-  final metadataFile = File('$directoryPath/$secureFileName.meta');
-  final metadata = {
-    'originalName': originalName,
-    'uploadedAt': DateTime.now().toIso8601String(),
-    'secureFileName': secureFileName,
-  };
-  await metadataFile.writeAsString(jsonEncode(metadata));
-}
-
-Map<String, dynamic>? _loadMetadata(
-  String directoryPath,
-  String secureFileName,
-) {
-  try {
-    final metadataFile = File('$directoryPath/$secureFileName.meta');
-    if (!metadataFile.existsSync()) return null;
-    final content = metadataFile.readAsStringSync();
-    return jsonDecode(content) as Map<String, dynamic>;
-  } catch (e) {
-    return null;
-  }
-}
-
-String _getDisplayName(String directoryPath, String secureFileName) {
-  final metadata = _loadMetadata(directoryPath, secureFileName);
-  return metadata?['originalName'] as String? ?? secureFileName;
-}
+import 'package:image_service/src/image_upload_utils.dart';
 
 Future<Response> onRequest(RequestContext context) async {
   return switch (context.request.method) {
@@ -112,7 +23,7 @@ Future<Response> _onGet(RequestContext context) async {
     return Response(statusCode: HttpStatus.unauthorized);
   }
 
-  final directory = Directory('data/images');
+  final directory = Directory(imageDirectory);
   if (!directory.existsSync()) {
     return Response(statusCode: HttpStatus.notFound);
   }
@@ -186,7 +97,7 @@ Future<Response> _onGet(RequestContext context) async {
                             attributes: {
                               'src':
                                   '/files/height=100/${file.path.split('/').last}',
-                              'alt': _getDisplayName(
+                              'alt': getDisplayName(
                                 directory.path,
                                 file.path.split('/').last,
                               ),
@@ -203,7 +114,7 @@ Future<Response> _onGet(RequestContext context) async {
                                 'font-medium text-sm text-gray-800 break-all',
                             children: [
                               Text(
-                                _getDisplayName(
+                                getDisplayName(
                                   directory.path,
                                   file.path.split('/').last,
                                 ),
@@ -289,42 +200,13 @@ Future<Response> _onPost(RequestContext context) async {
     }
 
     final bytes = await fileField.readAsBytes();
+    final originalFileName = fileField.name.isNotEmpty ? fileField.name : '';
 
-    // Security: Validate file size (max 10MB)
-    const maxFileSize = 10 * 1024 * 1024; // 10MB
-    if (bytes.length > maxFileSize) {
-      return Response(
-        statusCode: HttpStatus.requestEntityTooLarge,
-        body: 'File too large. Maximum size is 10MB.',
-      );
-    }
-
-    // Security: Validate file type by checking magic bytes
-    if (!_isValidImageFile(bytes)) {
-      return Response(
-        statusCode: HttpStatus.badRequest,
-        body:
-            'Invalid file type. Only images (JPEG, PNG, GIF, WebP) are allowed.',
-      );
-    }
-
-    // Security: Generate secure filename to prevent conflicts and traversal
-    final originalName = fileField.name.isNotEmpty ? fileField.name : 'image';
-    final extension = _getFileExtension(originalName);
-    final secureFileName = '${_generateSecureFileName()}$extension';
-
-    // Ensure the directory exists
-    final directory = Directory('data/images');
-    if (!directory.existsSync()) {
-      directory.createSync(recursive: true);
-    }
-
-    // Save the file with secure filename
-    final file = File('${directory.path}/$secureFileName');
-    await file.writeAsBytes(bytes);
-
-    // Save metadata with original filename
-    await _saveMetadata(directory.path, secureFileName, originalName);
+    // Process the upload using shared utilities
+    final result = await processImageUpload(
+      bytes: bytes,
+      originalFileName: originalFileName,
+    );
 
     // Return a single table row for the newly uploaded file
     return HtmlResponse(
@@ -341,8 +223,8 @@ Future<Response> _onPost(RequestContext context) async {
                 className:
                     'rounded-lg shadow-md transition-transform duration-200 max-w-30 h-auto hover:scale-110',
                 attributes: {
-                  'src': '/files/height=100/$secureFileName',
-                  'alt': originalName,
+                  'src': '/files/height=100/${result.secureFileName}',
+                  'alt': result.originalName,
                 },
               ),
             ],
@@ -353,7 +235,7 @@ Future<Response> _onPost(RequestContext context) async {
             children: [
               Div(
                 className: 'font-medium text-sm text-gray-800 break-all',
-                children: [Text(originalName)],
+                children: [Text(result.originalName)],
               ),
             ],
           ),
@@ -365,7 +247,9 @@ Future<Response> _onPost(RequestContext context) async {
                 className:
                     'font-mono text-sm bg-gray-50 p-2 rounded border relative break-all whitespace-normal min-w-48',
                 children: [
-                  Text('https://images.joinclubhaus.com/files/$secureFileName'),
+                  Text(
+                    'https://images.joinclubhaus.com/files/${result.secureFileName}',
+                  ),
                 ],
               ),
             ],
@@ -378,7 +262,7 @@ Future<Response> _onPost(RequestContext context) async {
                 className: 'flex flex-col sm:flex-row gap-2',
                 children: [
                   A(
-                    href: '/files/$secureFileName',
+                    href: '/files/${result.secureFileName}',
                     className:
                         'text-blue-500 no-underline font-medium py-2 px-3 border border-blue-500 rounded text-sm transition-all duration-200 inline-block hover:bg-blue-500 hover:text-white text-center',
                     children: [const Text('View')],
@@ -387,7 +271,7 @@ Future<Response> _onPost(RequestContext context) async {
                     className:
                         'text-red-500 font-medium py-2 px-3 border border-red-500 rounded text-sm transition-all duration-200 hover:bg-red-500 hover:text-white cursor-pointer text-center',
                     attributes: {
-                      'hx-delete': '/files/$secureFileName',
+                      'hx-delete': '/files/${result.secureFileName}',
                       'hx-target': 'closest tr',
                       'hx-swap': 'outerHTML',
                       'hx-confirm':
@@ -402,6 +286,8 @@ Future<Response> _onPost(RequestContext context) async {
         ],
       ),
     );
+  } on ImageUploadException catch (e) {
+    return Response(statusCode: e.statusCode, body: e.message);
   } catch (e) {
     return Response(
       statusCode: HttpStatus.internalServerError,

--- a/routes/upload_tokens/[token].dart
+++ b/routes/upload_tokens/[token].dart
@@ -1,0 +1,59 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:image_service/src/image_upload_utils.dart';
+import 'package:image_service/src/temporary_upload_token_store.dart';
+
+Future<Response> onRequest(RequestContext context, String token) async {
+  return switch (context.request.method) {
+    HttpMethod.post => _onPost(context, token),
+    _ => Future.value(Response(statusCode: HttpStatus.methodNotAllowed)),
+  };
+}
+
+Future<Response> _onPost(RequestContext context, String token) async {
+  // Get token store from context
+  final tokenStore = context.read<TemporaryUploadTokenStore>();
+
+  // Validate and consume the token (single-use)
+  final isValidToken = tokenStore.validateAndConsumeToken(token);
+
+  if (!isValidToken) {
+    return Response(
+      statusCode: HttpStatus.unauthorized,
+      body: 'Invalid or expired token',
+    );
+  }
+
+  try {
+    final formData = await context.request.formData();
+    final fileField = formData.files['file'];
+
+    if (fileField == null) {
+      return Response(
+        statusCode: HttpStatus.badRequest,
+        body: 'No file provided',
+      );
+    }
+
+    final bytes = await fileField.readAsBytes();
+    final originalFileName = fileField.name.isNotEmpty ? fileField.name : '';
+
+    // Process the upload using shared utilities
+    final result = await processImageUpload(
+      bytes: bytes,
+      originalFileName: originalFileName,
+    );
+
+    return Response.json(body: result.toJson(), statusCode: HttpStatus.created);
+  } on ImageUploadException catch (e) {
+    return Response(statusCode: e.statusCode, body: e.message);
+  } catch (e) {
+    return Response(
+      statusCode: HttpStatus.internalServerError,
+      body: 'Upload failed: $e',
+    );
+  }
+}

--- a/routes/upload_tokens/index.dart
+++ b/routes/upload_tokens/index.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:image_service/src/temporary_upload_token_store.dart';
+
+Future<Response> onRequest(RequestContext context) async {
+  return switch (context.request.method) {
+    HttpMethod.post => _onPost(context),
+    _ => Future.value(Response(statusCode: HttpStatus.methodNotAllowed)),
+  };
+}
+
+Future<Response> _onPost(RequestContext context) async {
+  // Authenticate with API key
+  final secretKey = Platform.environment['SECRET_KEY'];
+  final requestApiKey = context.request.headers['x-api-key'];
+
+  if (secretKey == null ||
+      requestApiKey == null ||
+      secretKey != requestApiKey) {
+    return Response(statusCode: HttpStatus.unauthorized);
+  }
+
+  // Get token store from context
+  final tokenStore = context.read<TemporaryUploadTokenStore>();
+
+  // Generate new token
+  final (token, expiresAt) = tokenStore.generateToken();
+
+  // Calculate expiration time in seconds
+  final expiresIn = expiresAt.difference(DateTime.now()).inSeconds;
+
+  // Return token information
+  final response = {
+    'token': token,
+    'uploadUrl': '/upload_tokens/$token',
+    'expiresAt': expiresAt.toIso8601String(),
+    'expiresIn': expiresIn,
+  };
+
+  return Response.json(body: response, statusCode: HttpStatus.created);
+}


### PR DESCRIPTION
- Add secure temporary upload token generation (15-min expiration, single-use)
- Create POST /upload_tokens endpoint to generate tokens (authenticated)
- Create POST /upload_tokens/{token} endpoint for token-based uploads (unauthenticated)
- Add TemporaryUploadTokenStore with cryptographically secure token generation
- Refactor upload logic into shared utilities (lib/src/image_upload_utils.dart)
- Add createTemporaryUploadUrl() and uploadImageWithToken() to client library
- Add TemporaryUploadUrl model with serialization support
- Update documentation with temporary upload URL usage examples
- Add comprehensive changelogs for both server and client library

Security:
- Tokens are single-use and automatically deleted after upload
- 32-byte cryptographically secure random token generation
- 15-minute token expiration with automatic cleanup
- Same security validations apply (magic byte checking, 10MB limit)
- Provides secure alternative to exposing API keys in client applications