### PR TITLE
feat: Add upload from URL support

### DIFF
--- a/image_service_client/README.md
+++ b/image_service_client/README.md
@@ -8,6 +8,7 @@ A Dart client library for interacting with the Image Service server. Provides a 
 ## Features
 
 - 📤 **Upload Images** - Multipart form upload or binary PUT with custom filename
+- 🌐 **Upload from URL** - Fetch and store images from public URLs
 - ⏰ **Temporary Upload URLs** - Generate secure, single-use tokens for client-side uploads
 - 📥 **Retrieve Images** - Get original or transformed versions
 - 🎨 **Transform Images** - On-the-fly resizing and quality adjustment
@@ -95,6 +96,45 @@ print('Uploaded: ${response.url}');
 - Expires after 15 minutes
 - Cryptographically secure (32 random bytes)
 - Perfect for client-side uploads without exposing API keys
+
+**Upload from a public URL:**
+
+You can also upload images directly from a public URL. The server will fetch the image and store it for you.
+
+```dart
+// Upload from URL (requires API key)
+final response = await client.uploadImageFromUrl(
+  url: 'https://example.com/image.jpg',
+);
+
+print('Uploaded: ${response.url}');
+```
+
+**With custom filename:**
+
+```dart
+final response = await client.uploadImageFromUrl(
+  url: 'https://example.com/image.jpg',
+  fileName: 'my-custom-name.jpg',
+);
+```
+
+**With bucket:**
+
+```dart
+final response = await client.uploadImageFromUrl(
+  url: 'https://example.com/image.jpg',
+  bucket: 'avatars',
+);
+```
+
+**Features:**
+
+- Requires API key authentication
+- 10 second timeout for fetching the image
+- Returns 400 Bad Request if URL is invalid or unreachable
+- Supports optional custom filename and bucket parameters
+- Filename is extracted from URL if not provided
 
 ### Retrieve an Image
 
@@ -195,15 +235,18 @@ Main client class for interacting with the Image Service.
 
 **Methods:**
 
-| Method                      | Description                     | Returns               |
-| --------------------------- | ------------------------------- | --------------------- |
-| `uploadImage()`             | Upload image via multipart form | `UploadResponse`      |
-| `uploadImageWithFilename()` | Upload with custom filename     | `UploadResponse`      |
-| `getImage()`                | Retrieve image bytes            | `Uint8List`           |
-| `getImageUrl()`             | Get image URL                   | `String`              |
-| `deleteImage()`             | Delete an image                 | `bool`                |
-| `listImages()`              | List all images                 | `List<ImageMetadata>` |
-| `dispose()`                 | Close HTTP client               | `void`                |
+| Method                       | Description                     | Returns               |
+| ---------------------------- | ------------------------------- | --------------------- |
+| `uploadImage()`              | Upload image via multipart form | `UploadResponse`      |
+| `uploadImageWithFilename()`  | Upload with custom filename     | `UploadResponse`      |
+| `uploadImageFromUrl()`       | Upload image from public URL    | `UploadResponse`      |
+| `createTemporaryUploadUrl()` | Create single-use upload token  | `TemporaryUploadUrl`  |
+| `uploadImageWithToken()`     | Upload using temporary token    | `UploadResponse`      |
+| `getImage()`                 | Retrieve image bytes            | `Uint8List`           |
+| `getImageUrl()`              | Get image URL                   | `String`              |
+| `deleteImage()`              | Delete an image                 | `bool`                |
+| `listImages()`               | List all images                 | `List<ImageMetadata>` |
+| `dispose()`                  | Close HTTP client               | `void`                |
 
 ### ImageTransformOptions
 

--- a/image_service_client/example/example.dart
+++ b/image_service_client/example/example.dart
@@ -91,15 +91,28 @@ Future<void> main() async {
     print('   Uploaded: ${tokenUpload.url}');
     print('   File name: ${tokenUpload.fileName}\n');
 
-    // Example 9: Delete images
-    print('9. Deleting images...');
+    // Example 9: Upload from public URL
+    print('9. Uploading from URL...');
+    try {
+      final urlUpload = await client.uploadImageFromUrl(
+        url: 'https://picsum.photos/200/300',
+        fileName: 'url-upload-example.jpg',
+      );
+      print('   Uploaded: ${urlUpload.url}');
+      print('   File name: ${urlUpload.fileName}\n');
+    } catch (e) {
+      print('   Failed to upload from URL (this is okay if no internet): $e\n');
+    }
+
+    // Example 10: Delete images
+    print('10. Deleting images...');
     await client.deleteImage(uploadResponse.fileName);
     print('   Deleted: ${uploadResponse.fileName}');
     await client.deleteImage(tokenUpload.fileName);
     print('   Deleted: ${tokenUpload.fileName}\n');
 
-    // Example 10: Error handling
-    print('10. Error handling example...');
+    // Example 11: Error handling
+    print('11. Error handling example...');
     try {
       await client.getImage('non-existent-file.jpg');
     } on ImageServiceException catch (e) {

--- a/image_service_client/lib/src/image_service_client.dart
+++ b/image_service_client/lib/src/image_service_client.dart
@@ -75,6 +75,51 @@ class ImageServiceClient {
     );
   }
 
+  /// Uploads an image from a public URL
+  ///
+  /// The server will fetch the image from the provided URL and store it.
+  /// Requires API key authentication.
+  ///
+  /// [url] - The public URL of the image to upload
+  /// [fileName] - Optional custom filename (if not provided, extracted from
+  /// URL)
+  /// [bucket] - Optional bucket name for organizing images
+  ///
+  /// Returns [UploadResponse] with the URL and metadata
+  ///
+  /// Throws [ImageServiceException] on failure (invalid URL, fetch error, etc.)
+  Future<UploadResponse> uploadImageFromUrl({
+    required String url,
+    String? fileName,
+    String? bucket,
+  }) async {
+    final uri = Uri.parse('$baseUrl/files/upload-from-url');
+    final body = <String, dynamic>{
+      'url': url,
+      if (fileName != null && fileName.isNotEmpty) 'fileName': fileName,
+      if (bucket != null && bucket.isNotEmpty) 'bucket': bucket,
+    };
+
+    final response = await _httpClient.post(
+      uri,
+      headers: {
+        ..._authHeaders,
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(body),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      return UploadResponse.fromMap(json);
+    }
+
+    throw ImageServiceException(
+      statusCode: response.statusCode,
+      message: response.body,
+    );
+  }
+
   /// Retrieves an image by filename
   ///
   /// [fileName] - The filename of the image

--- a/image_service_client/test/src/image_service_client_test.dart
+++ b/image_service_client/test/src/image_service_client_test.dart
@@ -180,5 +180,181 @@ void main() {
         );
       });
     });
+
+    group('uploadImageFromUrl', () {
+      test('uploads image from URL successfully', () async {
+        final jsonResponse = {
+          'url': 'http://localhost:8080/files/123456_789.jpg',
+          'fileName': '123456_789.jpg',
+          'originalName': 'photo.jpg',
+        };
+
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(jsonEncode(jsonResponse), 201),
+        );
+
+        final result = await client.uploadImageFromUrl(
+          url: 'https://example.com/photo.jpg',
+        );
+
+        expect(result.fileName, equals('123456_789.jpg'));
+        expect(result.originalName, equals('photo.jpg'));
+        verify(
+          () => mockClient.post(
+            Uri.parse('http://localhost:8080/files/upload-from-url'),
+            headers: {
+              'x-api-key': 'test-api-key',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode({'url': 'https://example.com/photo.jpg'}),
+          ),
+        ).called(1);
+      });
+
+      test('uploads image from URL with custom filename', () async {
+        final jsonResponse = {
+          'url': 'http://localhost:8080/files/123456_789.png',
+          'fileName': '123456_789.png',
+          'originalName': 'custom.png',
+        };
+
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(jsonEncode(jsonResponse), 201),
+        );
+
+        final result = await client.uploadImageFromUrl(
+          url: 'https://example.com/photo.jpg',
+          fileName: 'custom.png',
+        );
+
+        expect(result.fileName, equals('123456_789.png'));
+        expect(result.originalName, equals('custom.png'));
+        verify(
+          () => mockClient.post(
+            Uri.parse('http://localhost:8080/files/upload-from-url'),
+            headers: {
+              'x-api-key': 'test-api-key',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode({
+              'url': 'https://example.com/photo.jpg',
+              'fileName': 'custom.png',
+            }),
+          ),
+        ).called(1);
+      });
+
+      test('uploads image from URL with bucket', () async {
+        final jsonResponse = {
+          'url': 'http://localhost:8080/files/avatars/123456_789.jpg',
+          'fileName': '123456_789.jpg',
+          'originalName': 'photo.jpg',
+          'bucket': 'avatars',
+        };
+
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(jsonEncode(jsonResponse), 201),
+        );
+
+        final result = await client.uploadImageFromUrl(
+          url: 'https://example.com/photo.jpg',
+          bucket: 'avatars',
+        );
+
+        expect(result.fileName, equals('123456_789.jpg'));
+        expect(result.originalName, equals('photo.jpg'));
+        verify(
+          () => mockClient.post(
+            Uri.parse('http://localhost:8080/files/upload-from-url'),
+            headers: {
+              'x-api-key': 'test-api-key',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode({
+              'url': 'https://example.com/photo.jpg',
+              'bucket': 'avatars',
+            }),
+          ),
+        ).called(1);
+      });
+
+      test('throws ImageServiceException on invalid URL', () async {
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response('Invalid URL format', 400),
+        );
+
+        expect(
+          () => client.uploadImageFromUrl(
+            url: 'not-a-valid-url',
+          ),
+          throwsA(isA<ImageServiceException>()),
+        );
+      });
+
+      test('throws ImageServiceException on fetch failure', () async {
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            'Failed to fetch image from URL: HTTP 404',
+            400,
+          ),
+        );
+
+        expect(
+          () => client.uploadImageFromUrl(
+            url: 'https://example.com/missing.jpg',
+          ),
+          throwsA(isA<ImageServiceException>()),
+        );
+      });
+
+      test('throws ImageServiceException on unauthorized', () async {
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response('Unauthorized', 401),
+        );
+
+        expect(
+          () => client.uploadImageFromUrl(
+            url: 'https://example.com/photo.jpg',
+          ),
+          throwsA(isA<ImageServiceException>()),
+        );
+      });
+    });
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   http_methods:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   dart_frog: ^1.1.0
   dart_frog_html: ^0.0.1
   hive_ce: ^2.15.0
+  http: ^1.3.0
   image: ^4.5.4
   mime: ^2.0.0
   path: ^1.9.1

--- a/routes/files/upload-from-url.dart
+++ b/routes/files/upload-from-url.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:http/http.dart' as http;
+import 'package:image_service/src/image_upload_utils.dart';
+import 'package:image_service/src/metadata.dart';
+
+Future<Response> onRequest(RequestContext context) async {
+  return switch (context.request.method) {
+    HttpMethod.post => _onPost(context),
+    _ => Future.value(Response(statusCode: HttpStatus.methodNotAllowed)),
+  };
+}
+
+Future<Response> _onPost(RequestContext context) async {
+  // Authenticate with API key
+  final secretKey = Platform.environment['SECRET_KEY'];
+  final requestApiKey = context.request.headers['x-api-key'];
+
+  if (secretKey == null ||
+      requestApiKey == null ||
+      secretKey != requestApiKey) {
+    return Response(statusCode: HttpStatus.unauthorized);
+  }
+
+  try {
+    // Parse JSON body
+    final body = await context.request.json() as Map<String, dynamic>;
+    final imageUrl = body['url'] as String?;
+    final fileName = body['fileName'] as String?;
+    final bucket = body['bucket'] as String?;
+
+    if (imageUrl == null || imageUrl.isEmpty) {
+      return Response(
+        statusCode: HttpStatus.badRequest,
+        body: 'Missing required field: url',
+      );
+    }
+
+    // Validate URL format
+    final Uri uri;
+    try {
+      uri = Uri.parse(imageUrl);
+      if (!uri.hasScheme || (!uri.isScheme('http') && !uri.isScheme('https'))) {
+        return Response(
+          statusCode: HttpStatus.badRequest,
+          body: 'Invalid URL: must be http or https',
+        );
+      }
+    } catch (e) {
+      return Response(
+        statusCode: HttpStatus.badRequest,
+        body: 'Invalid URL format',
+      );
+    }
+
+    // Fetch the image from the URL with 10 second timeout
+    final client = http.Client();
+    try {
+      final response = await client
+          .get(uri)
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200) {
+        return Response(
+          statusCode: HttpStatus.badRequest,
+          body: 'Failed to fetch image from URL: HTTP ${response.statusCode}',
+        );
+      }
+
+      final bytes = response.bodyBytes;
+
+      // Determine filename
+      String originalFileName;
+      if (fileName != null && fileName.isNotEmpty) {
+        originalFileName = fileName;
+      } else {
+        // Extract filename from URL path
+        final pathSegments = uri.pathSegments;
+        if (pathSegments.isNotEmpty) {
+          originalFileName = pathSegments.last;
+        } else {
+          originalFileName = 'image.jpg';
+        }
+      }
+
+      // Get metadata store from context
+      final metadataStore = context.read<ImageMetadataStore>();
+
+      // Process the upload using shared utilities
+      final result = await processImageUpload(
+        bytes: bytes,
+        originalFileName: originalFileName,
+        metadataStore: metadataStore,
+        bucket: bucket,
+      );
+
+      return Response.json(
+        body: result.toJson(),
+        statusCode: HttpStatus.created,
+      );
+    } on TimeoutException {
+      return Response(
+        statusCode: HttpStatus.badRequest,
+        body: 'Failed to fetch image from URL: Request timed out',
+      );
+    } on http.ClientException catch (e) {
+      return Response(
+        statusCode: HttpStatus.badRequest,
+        body: 'Failed to fetch image from URL: ${e.message}',
+      );
+    } on ImageUploadException catch (e) {
+      return Response(statusCode: e.statusCode, body: e.message);
+    } finally {
+      client.close();
+    }
+  } catch (e) {
+    return Response(
+      statusCode: HttpStatus.badRequest,
+      body: 'Invalid request: $e',
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds the ability to upload images from public URLs with API key authentication.

## Changes

### Server
- New `/files/upload-from-url` POST endpoint
- Requires API key authentication via `x-api-key` header
- Fetches images from public URLs with 10-second timeout
- Validates URL format (must be http/https)
- Returns 400 Bad Request on invalid/unreachable URLs
- Extracts filename from URL if not provided
- Supports optional `fileName` and `bucket` parameters

### Client
- New `uploadImageFromUrl()` method in `ImageServiceClient`
- Parameters: `url` (required), `fileName` (optional), `bucket` (optional)
- Returns `UploadResponse` with URL and metadata
- Throws `ImageServiceException` on errors

### Tests
- Added 6 comprehensive test cases covering:
  - Successful upload from URL
  - Upload with custom filename
  - Upload with bucket
  - Error handling for invalid URLs, fetch failures, and unauthorized requests
- All 22 tests passing ✅

### Documentation
- Updated README with usage examples and feature description
- Updated example.dart with working example
- Updated API reference table

## Usage Example

```dart
final client = ImageServiceClient(
  baseUrl: 'http://localhost:8080',
  apiKey: 'your-api-key',
);

// Upload from URL
final response = await client.uploadImageFromUrl(
  url: 'https://example.com/image.jpg',
  fileName: 'my-image.jpg',  // optional
  bucket: 'avatars',         // optional
);

print('Uploaded: ${response.url}');
```

## Testing
- ✅ All tests passing (22/22)
- ✅ No linter errors
- ✅ dart analyze clean