### PR TITLE
fix: Update dashboard to use /dashboard/files endpoints

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Fetch and display images table
   function fetchImagesTable(apiKey) {
-    fetch('/files', {
+    fetch('/dashboard/files', {
       headers: {
         'x-api-key': apiKey
       }
@@ -404,7 +404,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Setup filter after images are loaded
   const originalFetchImagesTable = fetchImagesTable;
   fetchImagesTable = function (apiKey) {
-    fetch('/files', {
+    fetch('/dashboard/files', {
       headers: {
         'x-api-key': apiKey
       }

--- a/routes/dashboard/index.dart
+++ b/routes/dashboard/index.dart
@@ -53,7 +53,7 @@ Future<Response> onRequest(RequestContext context) async {
                       className:
                           'mb-8 p-6 bg-white rounded-lg border border-gray-200 shadow-sm',
                       attributes: {
-                        'hx-post': '/files',
+                        'hx-post': '/dashboard/files',
                         'hx-encoding': 'multipart/form-data',
                         'hx-target': '#table-body',
                         'hx-swap': 'afterbegin',


### PR DESCRIPTION
## Summary

Fixes the dashboard to use its own dedicated endpoints instead of the public file API endpoints.

## Changes

### Frontend (public/main.js)
- Updated `fetchImagesTable()` to use `/dashboard/files` instead of `/files`
- Ensures proper separation between dashboard operations and public API

### Backend (routes/dashboard/index.dart)
- Updated HTMX upload form to post to `/dashboard/files` instead of `/files`
- Maintains consistency with the frontend fetch requests

## Motivation

The dashboard should use its own authenticated endpoints (`/dashboard/files`) rather than the public file API (`/files`). This:

1. **Clarifies intent**: Dashboard operations are distinct from public file access
2. **Maintains consistency**: All dashboard operations go through `/dashboard/*` routes
3. **Prevents confusion**: Separates authenticated dashboard functionality from public file serving

## Testing

- ✅ Dashboard upload still works correctly
- ✅ Image listing in dashboard functions properly
- ✅ No functional changes, only endpoint paths updated