### PR TITLE
feat: encode images based on file extension in transformation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-dev.6]
+
+### Changed
+
+#### Server
+
+- **Image transformation encoding**: Image transformation endpoint now encodes images based on file extension
+  - `GET /files/{propertiesString}/{fileName}` now preserves original image format during transformation
+  - JPEG files (`.jpg`, `.jpeg`) are encoded as JPEG with quality parameter
+  - PNG files (`.png`) are encoded as PNG (lossless)
+  - GIF files (`.gif`) are encoded as GIF
+  - Unknown extensions default to JPEG encoding
+  - Content-Type header now matches the encoded format
+  - Previously all transformed images were always encoded as JPEG regardless of source format
+
 ## [0.0.1-dev.5] - 2025-10-20
 
 ### Changed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_service
 description: A service for storing and retrieving images
-version: 0.0.1-dev.5
+version: 0.0.1-dev.6
 publish_to: none
 
 environment:

--- a/routes/files/[propertiesString]/[fileName].dart
+++ b/routes/files/[propertiesString]/[fileName].dart
@@ -40,15 +40,41 @@ Future<Response> _onGet(
   final qualityString = properties['quality'];
   final quality = qualityString != null ? int.parse(qualityString) : 100;
 
+  // Extract extension from fileName
+  final extension = getFileExtension(fileName);
+
   final command = image.Command()
     ..decodeImageFile(file.path)
-    ..copyResize(width: width, height: height)
-    ..encodeJpg(quality: quality);
+    ..copyResize(width: width, height: height);
+
+  // Encode based on extension
+  String contentType;
+  switch (extension) {
+    case '.jpg':
+    case '.jpeg':
+      command.encodeJpg(quality: quality);
+      contentType = 'image/jpeg';
+    case '.png':
+      command.encodePng();
+      contentType = 'image/png';
+    case '.gif':
+      command.encodeGif();
+      contentType = 'image/gif';
+    case '.webp':
+      // WebP encoding not available in Command API, encode as PNG (lossless)
+      // to preserve quality since WebP can be lossless
+      command.encodePng();
+      contentType = 'image/png';
+    default:
+      // Default to JPEG if extension is unknown
+      command.encodeJpg(quality: quality);
+      contentType = 'image/jpeg';
+  }
 
   final processedImage = await command.execute();
 
   return Response.bytes(
     body: processedImage.outputBytes,
-    headers: {'content-type': 'image/jpeg'},
+    headers: {'content-type': contentType},
   );
 }


### PR DESCRIPTION
## Summary

This PR updates the image transformation endpoint to encode images based on their file extension, preserving the original format during transformation.

## Changes

- **Image transformation encoding**: The `GET /files/{propertiesString}/{fileName}` endpoint now preserves original image format during transformation
  - JPEG files (`.jpg`, `.jpeg`) are encoded as JPEG with quality parameter
  - PNG files (`.png`) are encoded as PNG (lossless)
  - GIF files (`.gif`) are encoded as GIF
  - WebP files (`.webp`) are encoded as PNG (lossless) since WebP encoding is not available in the Command API
  - Unknown extensions default to JPEG encoding
  - Content-Type header now matches the encoded format

## Fixes

- Fixes issue where WebP files were incorrectly falling through to the default case and being encoded as JPEG with incorrect content-type headers
- Previously all transformed images were always encoded as JPEG regardless of source format

## Version

Bumps version to `0.0.1-dev.6`